### PR TITLE
created a webcam class and dummy class

### DIFF
--- a/AutoPylot/cameras/camera.py
+++ b/AutoPylot/cameras/camera.py
@@ -1,0 +1,29 @@
+"""Wrapper for cameras."""
+from .webcam import Webcam
+from .dummy import Dummy
+
+
+class Camera(Webcam, Dummy):
+    """Camera class.
+
+    Args:
+        Webcam (class): Webcam camera
+        Dummy (class): Dummy camera
+    """
+
+    def __init__(self, camera_type="webcam", shape=(160, 120, 3), *args, **kwargs):
+        """Tnit class.
+
+        Args:
+            camera_type (str, optional): [description]. Defaults to "webcam".
+            shape (tuple, optional): [description]. Defaults to (160, 120, 3).
+
+        Raises:
+            ValueError: raise a valueError if camera_type is not supported.
+        """
+        if camera_type == "webcam":
+            Webcam.__init__(self, *args, **kwargs, shape=shape)
+        elif camera_type == "dummy":
+            Dummy.__init__(self, *args, **kwargs, shape=shape)
+        else:
+            raise ValueError("Unknown camera type")

--- a/AutoPylot/cameras/dummy.py
+++ b/AutoPylot/cameras/dummy.py
@@ -1,0 +1,24 @@
+
+import numpy as np
+
+
+class Dummy():
+    """Dummy camera."""
+
+    def __init__(self, shape=(160, 120, 3)):
+        """Camera init.
+
+        Args:
+            shape (tuple, optional): shape of the output image. Defaults to (160, 120, 3).
+        """
+
+        self.shape = shape
+        assert self.shape[-1] == 3 or self.shape[-1] == 1, "Image last dimension should be either 3 (RGB) or 1 (GREY)"
+
+    def read(self):
+        """Create a dummy image.
+
+        Returns:
+            np.array: image
+        """
+        return np.zeros(self.shape, dtype=np.float32)

--- a/AutoPylot/cameras/dummy.py
+++ b/AutoPylot/cameras/dummy.py
@@ -1,4 +1,4 @@
-
+"""Dummy camera for testing purposes."""
 import numpy as np
 
 

--- a/AutoPylot/cameras/dummy.py
+++ b/AutoPylot/cameras/dummy.py
@@ -13,6 +13,9 @@ class Dummy():
         """
 
         self.shape = shape
+        self.h = shape[0]
+        self.w = shape[1]
+        assert len(self.shape) == 3, "Shape should have 3 dimensions"
         assert self.shape[-1] == 3 or self.shape[-1] == 1, "Image last dimension should be either 3 (RGB) or 1 (GREY)"
 
     def read(self):

--- a/AutoPylot/cameras/webcam.py
+++ b/AutoPylot/cameras/webcam.py
@@ -1,3 +1,4 @@
+"""Webcam camera."""
 import cv2
 
 
@@ -16,21 +17,12 @@ class Webcam:
         assert ret, "Couldn't read from camera"
 
         self.shape = shape
+        assert len(self.shape) == 3, "Shape should have 3 dimensions"
         self.h = shape[0]
         self.w = shape[1]
-        assert len(self.shape) == 3, "Shape should have 3 dimensions"
-        assert self.shape[-1] == 3 or self.shape[-1] == 1, "Image last dimension should be either 3 (RGB) or 1 (GREY)"
-
-    def _resize(self, img):
-        """Resize the image to the given shape of output image.
-
-        Args:
-            img (np.array): image
-
-        Returns:
-            np.array: resized image
-        """
-        return cv2.resize(img, (self.w, self.h))
+        self.c = shape[2]
+        assert self.c in [
+            1, 3], "Image last dimension should be either 3 (RGB) or 1 (GREY)"
 
     def read(self):
         """Read image from the camera.
@@ -43,6 +35,7 @@ class Webcam:
         """
         ret, img = self.cap.read()
         if ret:
-            return self.resize(img)
+            img = cv2.resize(img, (self.w, self.h))
+            return img if self.c == 3 else cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
         else:
             raise ValueError("Image read failed")

--- a/AutoPylot/cameras/webcam.py
+++ b/AutoPylot/cameras/webcam.py
@@ -19,8 +19,9 @@ class Webcam:
         self.h = shape[0]
         self.w = shape[1]
         assert len(self.shape) == 3, "Shape should have 3 dimensions"
+        assert self.shape[-1] == 3 or self.shape[-1] == 1, "Image last dimension should be either 3 (RGB) or 1 (GREY)"
 
-    def resize(self, img):
+    def _resize(self, img):
         """Resize the image to the given shape of output image.
 
         Args:

--- a/AutoPylot/cameras/webcam.py
+++ b/AutoPylot/cameras/webcam.py
@@ -1,0 +1,47 @@
+import cv2
+
+
+class Webcam:
+    """Webcam class."""
+
+    def __init__(self, index=0, shape=(160, 120, 3)):
+        """Camera init.
+
+        Args:
+            index (int, optional): index of the camera. Defaults to 0.
+            shape (tuple, optional): shape of the output image. Defaults to (160, 120, 3).
+        """
+        self.cap = cv2.VideoCapture(index)
+        ret, img = self.cap.read()
+        assert ret, "Couldn't read from camera"
+
+        self.shape = shape
+        self.h = shape[0]
+        self.w = shape[1]
+        assert len(self.shape) == 3, "Shape should have 3 dimensions"
+
+    def resize(self, img):
+        """Resize the image to the given shape of output image.
+
+        Args:
+            img (np.array): image
+
+        Returns:
+            np.array: resized image
+        """
+        return cv2.resize(img, (self.w, self.h))
+
+    def read(self):
+        """Read image from the camera.
+
+        Raises:
+            ValueError: if couldn't grab the image, raise a valueError.
+
+        Returns:
+            np.array: resized image
+        """
+        ret, img = self.cap.read()
+        if ret:
+            return self.resize(img)
+        else:
+            raise ValueError("Image read failed")


### PR DESCRIPTION
[draft]
About #4 

This PR will add cameras (webcam and dummy) to the project. Having a normalized way to fetch images (including resizing etc) will be useful.

The normal camera uses opencv to fetch images from a usb camera.
The dummy one creates a new black image (for testing purpose for example)

I will implement a wrapper for those kind of cameras so that we will only need to select "Webcam" or "Dummy" later.

note : I won't make the "dataset" camera for  the moment as this part isn't ready yet, so we will stick with the normal and dummy camera.